### PR TITLE
bugfix max ram arduino due

### DIFF
--- a/programs/bmptk/Makefile.inc
+++ b/programs/bmptk/Makefile.inc
@@ -871,7 +871,7 @@ endif
 define Atmel_SAM3
    $(eval $(Cortex-M3))
    ROM_START      ?= 0x00000000   
-   RAM_START      ?= 0x20000000     
+   RAM_START      ?= 0x20070000     
    INCLUDES       += -I$(BMPTK)/targets/cortex/atmel
    PORT_CHECK     ?= $(CHECK_PORT) $(SERIAL_PORT)  
    RUN_PRE        := $(DUE_BOOTMODE)

--- a/programs/bmptk/targets/cortex/atmel/sam3xa/source/as_gcc/sam3x8e_flash.ld
+++ b/programs/bmptk/targets/cortex/atmel/sam3xa/source/as_gcc/sam3x8e_flash.ld
@@ -39,7 +39,7 @@ SEARCH_DIR(.)
 MEMORY
 {
   rom (rx)  : ORIGIN = 0x00080000, LENGTH = 0x00080000
-  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00018000
+  ram (rwx) : ORIGIN = 0x20070000, LENGTH = 0x00018000
 }
 
 /* The stack size used by the application. NOTE: you need to adjust according to your application. */


### PR DESCRIPTION
This bugfix fixes a bug that is in bmptk. see: [bmptk](https://github.com/wovo/bmptk/pull/4)