### PR TITLE
Vscode task relative path error

### DIFF
--- a/modules/.vscode/tasks.json
+++ b/modules/.vscode/tasks.json
@@ -1,0 +1,22 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "bmptk-make",
+            "type": "shell",
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "command": "echo \"Please open a module folder\""
+        }
+    ]
+}

--- a/modules/template-arduino/.vscode/tasks.json
+++ b/modules/template-arduino/.vscode/tasks.json
@@ -18,7 +18,7 @@
             ],
 
             "windows": {
-                "command": "../../../programs/bmptk/tools/bmptk-make.exe",
+                "command": "bmptk-make run",
             },
 
             "linux": {
@@ -37,7 +37,7 @@
             ],
 
             "windows": {
-                "command": "../../../programs/bmptk/tools/bmptk-make.exe clean build",
+                "command": "bmptk-make clean build",
             },
 
             "linux": {
@@ -56,7 +56,7 @@
             ],
 
             "windows": {
-                "command": "../../../programs/bmptk/tools/bmptk-make.exe run",
+                "command": "bmptk-make run",
             },
 
             "linux": {

--- a/modules/template-arduino/.vscode/tasks.json
+++ b/modules/template-arduino/.vscode/tasks.json
@@ -1,0 +1,67 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "bmptk-make",
+            "type": "shell",
+            "options": {
+                "cwd": "${workspaceFolder}/code"
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": [
+                "$gcc"
+            ],
+
+            "windows": {
+                "command": "../../../programs/bmptk/tools/bmptk-make.exe",
+            },
+
+            "linux": {
+                "command": "make",
+            }
+        },
+        {
+            "label": "bmptk-make rebuild",
+            "type": "shell",
+            "options": {
+                "cwd": "${workspaceFolder}/code"
+            },
+            "group": "build",
+            "problemMatcher": [
+                "$gcc"
+            ],
+
+            "windows": {
+                "command": "../../../programs/bmptk/tools/bmptk-make.exe clean build",
+            },
+
+            "linux": {
+                "command": "make clean build",
+            }
+        },
+        {
+            "label": "bmptk-make upload",
+            "type": "shell",
+            "options": {
+                "cwd": "${workspaceFolder}/code"
+            },
+            "group": "build",
+            "problemMatcher": [
+                "$gcc"
+            ],
+
+            "windows": {
+                "command": "../../../programs/bmptk/tools/bmptk-make.exe run",
+            },
+
+            "linux": {
+                "command": "make run",
+            }
+        }
+    ]
+}

--- a/modules/template-native/.vscode/tasks.json
+++ b/modules/template-native/.vscode/tasks.json
@@ -43,25 +43,6 @@
             "linux": {
                 "command": "make clean build",
             }
-        },
-        {
-            "label": "bmptk-make upload",
-            "type": "shell",
-            "options": {
-                "cwd": "${workspaceFolder}/code"
-            },
-            "group": "build",
-            "problemMatcher": [
-                "$gcc"
-            ],
-
-            "windows": {
-                "command": "bmptk-make run",
-            },
-
-            "linux": {
-                "command": "make run",
-            }
         }
     ]
 }

--- a/modules/template-native/.vscode/tasks.json
+++ b/modules/template-native/.vscode/tasks.json
@@ -18,7 +18,7 @@
             ],
 
             "windows": {
-                "command": "../../../programs/bmptk/tools/bmptk-make.exe",
+                "command": "bmptk-make",
             },
 
             "linux": {
@@ -37,7 +37,7 @@
             ],
 
             "windows": {
-                "command": "../../../programs/bmptk/tools/bmptk-make.exe clean build",
+                "command": "bmptk-make clean build",
             },
 
             "linux": {

--- a/modules/template-native/.vscode/tasks.json
+++ b/modules/template-native/.vscode/tasks.json
@@ -1,0 +1,48 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "bmptk-make",
+            "type": "shell",
+            "options": {
+                "cwd": "${workspaceFolder}/code"
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": [
+                "$gcc"
+            ],
+
+            "windows": {
+                "command": "../../../programs/bmptk/tools/bmptk-make.exe",
+            },
+
+            "linux": {
+                "command": "make",
+            }
+        },
+        {
+            "label": "bmptk-make rebuild",
+            "type": "shell",
+            "options": {
+                "cwd": "${workspaceFolder}/code"
+            },
+            "group": "build",
+            "problemMatcher": [
+                "$gcc"
+            ],
+
+            "windows": {
+                "command": "../../../programs/bmptk/tools/bmptk-make.exe clean build",
+            },
+
+            "linux": {
+                "command": "make clean build",
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Relative path execution gave the following error:

> Executing task: ../../../programs/bmptk/tools/bmptk-make.exe <
'..' is not recognized as an internal or external command,
operable program or batch file.
The terminal process terminated with exit code: 1

Because bmptk-make.exe is in the path we can execute without using a relative path.