### PR TITLE
Task hotfix cmd

### DIFF
--- a/modules/template-arduino/.vscode/tasks.json
+++ b/modules/template-arduino/.vscode/tasks.json
@@ -18,7 +18,7 @@
             ],
 
             "windows": {
-                "command": "\"../../../programs/bmptk/tools/bmptk-make.exe\"",
+                "command": "..\\..\\..\\programs\\bmptk\\tools\\bmptk-make.exe",
             },
 
             "linux": {
@@ -31,13 +31,16 @@
             "options": {
                 "cwd": "${workspaceFolder}/code"
             },
-            "group": "build",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
             "problemMatcher": [
                 "$gcc"
             ],
 
             "windows": {
-                "command": "\"../../../programs/bmptk/tools/bmptk-make.exe clean build\"",
+                "command": "..\\..\\..\\programs\\bmptk\\tools\\bmptk-make.exe  clean build",
             },
 
             "linux": {
@@ -50,13 +53,16 @@
             "options": {
                 "cwd": "${workspaceFolder}/code"
             },
-            "group": "build",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
             "problemMatcher": [
                 "$gcc"
             ],
 
             "windows": {
-                "command": "\"../../../programs/bmptk/tools/bmptk-make.exe run\"",
+                "command": "..\\..\\..\\programs\\bmptk\\tools\\bmptk-make.exe run",
             },
 
             "linux": {

--- a/modules/template-arduino/.vscode/tasks.json
+++ b/modules/template-arduino/.vscode/tasks.json
@@ -18,7 +18,7 @@
             ],
 
             "windows": {
-                "command": "../../../programs/bmptk/tools/bmptk-make.exe",
+                "command": "\"../../../programs/bmptk/tools/bmptk-make.exe\"",
             },
 
             "linux": {
@@ -37,7 +37,7 @@
             ],
 
             "windows": {
-                "command": "../../../programs/bmptk/tools/bmptk-make.exe clean build",
+                "command": "\"../../../programs/bmptk/tools/bmptk-make.exe clean build\"",
             },
 
             "linux": {
@@ -56,7 +56,7 @@
             ],
 
             "windows": {
-                "command": "../../../programs/bmptk/tools/bmptk-make.exe run",
+                "command": "\"../../../programs/bmptk/tools/bmptk-make.exe run\"",
             },
 
             "linux": {

--- a/modules/template-native/.vscode/tasks.json
+++ b/modules/template-native/.vscode/tasks.json
@@ -18,7 +18,7 @@
             ],
 
             "windows": {
-                "command": "\"../../../programs/bmptk/tools/bmptk-make.exe\"",
+                "command": "..\\..\\..\\programs\\bmptk\\tools\\bmptk-make.exe",
             },
 
             "linux": {
@@ -37,11 +37,30 @@
             ],
 
             "windows": {
-                "command": "\"../../../programs/bmptk/tools/bmptk-make.exe clean build\"",
+                "command": "..\\..\\..\\programs\\bmptk\\tools\\bmptk-make.exe  clean build",
             },
 
             "linux": {
                 "command": "make clean build",
+            }
+        },
+        {
+            "label": "bmptk-make run",
+            "type": "shell",
+            "options": {
+                "cwd": "${workspaceFolder}/code"
+            },
+            "group": "build",
+            "problemMatcher": [
+                "$gcc"
+            ],
+
+            "windows": {
+                "command": "..\\..\\..\\programs\\bmptk\\tools\\bmptk-make.exe run",
+            },
+
+            "linux": {
+                "command": "make run",
             }
         }
     ]

--- a/modules/template-native/.vscode/tasks.json
+++ b/modules/template-native/.vscode/tasks.json
@@ -18,7 +18,7 @@
             ],
 
             "windows": {
-                "command": "../../../programs/bmptk/tools/bmptk-make.exe",
+                "command": "\"../../../programs/bmptk/tools/bmptk-make.exe\"",
             },
 
             "linux": {
@@ -37,7 +37,7 @@
             ],
 
             "windows": {
-                "command": "../../../programs/bmptk/tools/bmptk-make.exe clean build",
+                "command": "\"../../../programs/bmptk/tools/bmptk-make.exe clean build\"",
             },
 
             "linux": {


### PR DESCRIPTION
Bugfix for not being able to run bmptk tasks when you changed the default integrated shell