### PR TITLE
modules folder added to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /programs/mingw32
 /programs/8 2018-q4-major
+/modules
 settings.json
-/modules/
 
 # un ignore certain items in the modules directory
 !/modules/template-arduino

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 /programs/mingw32
 /programs/8 2018-q4-major
 settings.json
+/modules/
+
+# un ignore certain items in the modules directory
+!/modules/template-arduino
+!/modules/template-native
+!/modules/.vscode
+!/modules/.clang-format


### PR DESCRIPTION
This pull request stops git from trying to add the modules as a submodule. 

The templates, the .vscode folder and the .clang-format are un-ignored.